### PR TITLE
Backward compatibility for pcap_setmintocopy(..) and update error message

### DIFF
--- a/jdk7/src/main/java/pcap/jdk7/internal/DefaultService.java
+++ b/jdk7/src/main/java/pcap/jdk7/internal/DefaultService.java
@@ -4,6 +4,7 @@
  */
 package pcap.jdk7.internal;
 
+import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.PointerByReference;
 import java.net.Inet4Address;
@@ -80,10 +81,15 @@ public class DefaultService implements Service {
       setTimestampPrecisionIfPossible(pointer, options);
     }
     setRfMonIfPossible(pointer, options.isRfmon(), canSetRfmon);
-    setImmediateModeIfPossible(pointer, options);
-    // end of platform dependent
-
-    checkActivate(pointer, NativeMappings.pcap_activate(pointer));
+    if ((Platform.isWindows() || Platform.isWindowsCE()) && options.isImmediate()) {
+      if (NativeMappings.PLATFORM_DEPENDENT.pcap_setmintocopy(pointer, 0) == -3) {
+        checkActivate(pointer, NativeMappings.pcap_activate(pointer));
+        checkSetImmediateMode(NativeMappings.PLATFORM_DEPENDENT.pcap_setmintocopy(pointer, 0));
+      }
+    } else {
+      setImmediateModeIfPossible(pointer, options);
+      checkActivate(pointer, NativeMappings.pcap_activate(pointer));
+    }
 
     DefaultPcap pcap = new DefaultPcap(pointer, netmask(source));
     if (options instanceof DefaultLiveOptions) {
@@ -114,13 +120,15 @@ public class DefaultService implements Service {
 
   void checkSetSnaplen(int result) throws ActivatedException {
     if (result != NativeMappings.OK) {
-      throw new ActivatedException("Error occurred when set snapshot length.");
+      throw new ActivatedException(
+          statusToString(result, "Error occurred when set snapshot length"));
     }
   }
 
   void checkSetPromisc(int result) throws ActivatedException {
     if (result != NativeMappings.OK) {
-      throw new ActivatedException("Error occurred when set promiscuous mode.");
+      throw new ActivatedException(
+          statusToString(result, "Error occurred when set promiscuous mode"));
     }
   }
 
@@ -133,18 +141,19 @@ public class DefaultService implements Service {
 
   boolean canSetRfmon(Pointer pointer, int result)
       throws ActivatedException, NoSuchDeviceException, ErrorException {
+    String message = "Error occurred when set radio frequency monitor mode";
     if (result == -4) {
-      throw new ActivatedException("Error occurred when set radio frequency monitor mode.");
+      throw new ActivatedException(statusToString(result, message));
     } else if (result == -5) {
-      throw new NoSuchDeviceException("Error occurred when set radio frequency monitor mode.");
+      throw new NoSuchDeviceException(statusToString(result, message));
     } else {
       if (result == -1) {
         throw new ErrorException(NativeMappings.pcap_geterr(pointer).getString(0));
       } else {
         if (result < 0) {
-          throw new ErrorException(NativeMappings.PLATFORM_DEPENDENT.pcap_statustostr(result));
+          throw new ErrorException(statusToString(result, message));
         } else {
-          Utils.warn(NativeMappings.PLATFORM_DEPENDENT.pcap_statustostr(result));
+          Utils.warn(statusToString(result, message));
         }
       }
     }
@@ -153,13 +162,14 @@ public class DefaultService implements Service {
 
   void checkSetRfmon(int result) throws ActivatedException {
     if (result != NativeMappings.OK) {
-      throw new ActivatedException("Error occurred when set radio frequency monitor mode.");
+      throw new ActivatedException(
+          statusToString(result, "Error occurred when set radio frequency monitor mode"));
     }
   }
 
   void checkSetTimeout(int result) throws ActivatedException {
     if (result != NativeMappings.OK) {
-      throw new ActivatedException("Error occurred when set timeout.");
+      throw new ActivatedException(statusToString(result, "Error occurred when set timeout"));
     }
   }
 
@@ -172,14 +182,13 @@ public class DefaultService implements Service {
 
   void checkSetTimestampType(int result)
       throws ActivatedException, InterfaceNotSupportTimestampTypeException {
+    String message = "Error occurred when set timestamp type";
     if (result == -4) {
-      throw new ActivatedException("Error occurred when set timestamp type.");
+      throw new ActivatedException(statusToString(result, message));
     } else if (result == -10) {
-      throw new InterfaceNotSupportTimestampTypeException(
-          "Error occurred when set timestamp type.");
+      throw new InterfaceNotSupportTimestampTypeException(statusToString(result, message));
     } else if (result == 3) {
-      Utils.warn(
-          "pcap_set_tstamp_type: " + NativeMappings.PLATFORM_DEPENDENT.pcap_statustostr(result));
+      Utils.warn(statusToString(result, message));
     }
   }
 
@@ -191,13 +200,14 @@ public class DefaultService implements Service {
 
   void checkSetImmediateMode(int result) throws ActivatedException {
     if (result != NativeMappings.OK) {
-      throw new ActivatedException("Error occurred when set immediate mode.");
+      throw new ActivatedException(
+          statusToString(result, "Error occurred when set immediate mode"));
     }
   }
 
   void checkSetBufferSize(int result) throws ActivatedException {
     if (result != NativeMappings.OK) {
-      throw new ActivatedException("Error occurred when set buffer size.");
+      throw new ActivatedException(statusToString(result, "Error occurred when set buffer size"));
     }
   }
 
@@ -210,11 +220,11 @@ public class DefaultService implements Service {
 
   void checkSetTimestampPrecision(int result)
       throws TimestampPrecisionNotSupportedException, ActivatedException {
+    String message = "Error occurred when set timestamp procision";
     if (result == -12) {
-      throw new TimestampPrecisionNotSupportedException(
-          "Error occurred when set timestamp procision.");
+      throw new TimestampPrecisionNotSupportedException(statusToString(result, message));
     } else if (result == -4) {
-      throw new ActivatedException("Error occurred when set timestamp procision.");
+      throw new ActivatedException(statusToString(result, message));
     }
   }
 
@@ -222,24 +232,38 @@ public class DefaultService implements Service {
       throws PromiscuousModePermissionDeniedException, RadioFrequencyModeNotSupportedException,
           InterfaceNotUpException, NoSuchDeviceException, ActivatedException,
           PermissionDeniedException {
+    String message = "Error occurred when activate a handle";
     if (result == 2) {
       throw new PromiscuousModeNotSupported(NativeMappings.pcap_geterr(pointer).getString(0));
     } else if (result == 3) {
-      Utils.warn("pcap_activate: " + NativeMappings.PLATFORM_DEPENDENT.pcap_statustostr(result));
+      Utils.warn(statusToString(result, message));
     } else if (result == 1) {
-      Utils.warn("pcap_activate: " + NativeMappings.PLATFORM_DEPENDENT.pcap_statustostr(result));
+      Utils.warn(statusToString(result, message));
     } else if (result == -4) {
-      throw new ActivatedException("Error occurred when activate a handle.");
+      throw new ActivatedException(statusToString(result, message));
     } else if (result == -5) {
       throw new NoSuchDeviceException(NativeMappings.pcap_geterr(pointer).getString(0));
     } else if (result == -8) {
       throw new PermissionDeniedException(NativeMappings.pcap_geterr(pointer).getString(0));
     } else if (result == -11) {
-      throw new PromiscuousModePermissionDeniedException("Error occurred when activate a handle.");
+      throw new PromiscuousModePermissionDeniedException(statusToString(result, message));
     } else if (result == -6) {
-      throw new RadioFrequencyModeNotSupportedException("Error occurred when activate a handle.");
+      throw new RadioFrequencyModeNotSupportedException(statusToString(result, message));
     } else if (result == -9) {
-      throw new InterfaceNotUpException("Error occurred when activate a handle.");
+      throw new InterfaceNotUpException(statusToString(result, message));
+    }
+  }
+
+  String statusToString(int rc, String fallback) {
+    try {
+      return NativeMappings.PLATFORM_DEPENDENT.pcap_statustostr(rc);
+    } catch (NullPointerException | UnsatisfiedLinkError e) {
+      StringBuilder sb = new StringBuilder();
+      sb.append(fallback);
+      sb.append(" (");
+      sb.append(rc);
+      sb.append(").");
+      return sb.toString();
     }
   }
 

--- a/jdk7/src/main/java/pcap/jdk7/internal/NativeMappings.java
+++ b/jdk7/src/main/java/pcap/jdk7/internal/NativeMappings.java
@@ -328,14 +328,7 @@ class NativeMappings {
       try {
         return NATIVE.pcap_set_immediate_mode(p, immediate_mode);
       } catch (NullPointerException | UnsatisfiedLinkError e) {
-        String message = "pcap_set_immediate_mode: Function doesn't exist.";
-        if (immediate_mode == 1 && Platform.isWindows()) {
-          Utils.warn(message + " Try calling pcap_setmintocopy.");
-          return pcap_setmintocopy(p, 0);
-        } else {
-          Utils.warn(message);
-          return 0;
-        }
+        return 0; // ignore immediate mode for libpcap version before 1.5.0
       }
     }
 
@@ -354,8 +347,7 @@ class NativeMappings {
       try {
         return NATIVE.pcap_get_selectable_fd(p);
       } catch (NullPointerException | UnsatisfiedLinkError e) {
-        Utils.warn("pcap_get_selectable_fd: Function doesn't exist.");
-        return -1;
+        throw new UnsupportedOperationException("pcap_get_selectable_fd: Function doesn't exist.");
       }
     }
 
@@ -374,8 +366,7 @@ class NativeMappings {
       try {
         return NATIVE.pcap_getevent(p);
       } catch (NullPointerException | UnsatisfiedLinkError e) {
-        Utils.warn("pcap_getevent: Function doesn't exist.");
-        return -1;
+        throw new UnsupportedOperationException("pcap_getevent: Function doesn't exist.");
       }
     }
 

--- a/jdk7/src/main/java/pcap/jdk7/internal/Utils.java
+++ b/jdk7/src/main/java/pcap/jdk7/internal/Utils.java
@@ -72,17 +72,21 @@ class Utils {
     if (version == null) {
       return true;
     }
-    if (MAJOR < version.major()) {
+    return isValidVersion(version.major(), version.minor(), version.patch());
+  }
+
+  static boolean isValidVersion(int major, int minor, int patch) {
+    if (MAJOR < major) {
       return false;
-    } else if (MAJOR > version.major()) {
+    } else if (MAJOR > major) {
       return true;
     } else {
-      if (MINOR < version.minor()) {
+      if (MINOR < minor) {
         return false;
-      } else if (MINOR > version.minor()) {
+      } else if (MINOR > minor) {
         return true;
       } else {
-        return PATCH >= version.patch();
+        return PATCH >= patch;
       }
     }
   }

--- a/tests/src/test/java/pcap/tests/Application.java
+++ b/tests/src/test/java/pcap/tests/Application.java
@@ -29,6 +29,7 @@ public class Application {
           NoSuchDeviceException, ActivatedException, InterfaceNotUpException,
           InterfaceNotSupportTimestampTypeException {
     Service service = Service.Creator.create("PcapService");
+    System.out.println(service.version());
     Interface devices = service.interfaces();
     for (Interface device : devices) {
       LOGGER.fine("[*] Device name   : " + device.name() + " (" + device.description() + ")");


### PR DESCRIPTION
Backward compatibility for pcap_setmintocopy(..) and update error message.
Winpcap or older version of Npcap doesn't support to set pcap_setmintocopy(..) on inactive capture.