### PR TITLE
Set 1 seconds for default timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,42 +60,42 @@ SPDX-License-Identifier: MIT OR Apache-2.0
         <java.jdk7.version>1.7</java.jdk7.version>
         <jdk.version>${java.version}</jdk.version>
 
-        <slf4j.version>1.7.32</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.10</logback.version>
         <log4j2.version>2.17.1</log4j2.version>
 
         <jna.version>5.10.0</jna.version>
         <jmh.version>1.34</jmh.version>
 
-        <mockito.version>4.2.0</mockito.version>
+        <mockito.version>4.3.1</mockito.version>
         <junit.jupiter.api.version>5.8.2</junit.jupiter.api.version>
         <junit.jupiter.engine.version>5.6.1</junit.jupiter.engine.version>
         <junit.platform.runner.version>1.8.2</junit.platform.runner.version>
 
         <fmt.maven.plugin.version>2.13</fmt.maven.plugin.version>
         <jacoco.maven.plugin.version>0.8.7</jacoco.maven.plugin.version>
-        <nexus.staging.maven.plugin.version>1.6.8</nexus.staging.maven.plugin.version>
+        <nexus.staging.maven.plugin.version>1.6.12</nexus.staging.maven.plugin.version>
         <sonar.maven.plugin.version>3.9.1.2184</sonar.maven.plugin.version>
         <modulemaker-maven-plugin.version>1.7</modulemaker-maven-plugin.version>
         <asm.version>9.2</asm.version>
 
         <maven.assembly.plugin.version>3.3.0</maven.assembly.plugin.version>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
-        <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
-        <maven.javadoc.plugin.version>3.3.1</maven.javadoc.plugin.version>
+        <maven.jar.plugin.version>3.2.2</maven.jar.plugin.version>
+        <maven.javadoc.plugin.version>3.3.2</maven.javadoc.plugin.version>
         <maven.toolchains.plugin.version>3.0.0</maven.toolchains.plugin.version>
-        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.10.0</maven.compiler.plugin.version>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
         <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
         <maven.install.plugin.version>2.5.2</maven.install.plugin.version>
         <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
-        <maven.site.plugin.version>3.10.0</maven.site.plugin.version>
+        <maven.site.plugin.version>3.11.0</maven.site.plugin.version>
         <maven.jxr.plugin.version>3.1.1</maven.jxr.plugin.version>
         <maven.gpg.plugin.version>3.0.1</maven.gpg.plugin.version>
         <maven.enforcer.plugin.version>3.0.0</maven.enforcer.plugin.version>
         <maven.failsafe.plugin.version>2.22.2</maven.failsafe.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M5</maven.surefire.plugin.version>
-        <maven.project.info.reports.plugin.version>3.1.2</maven.project.info.reports.plugin.version>
+        <maven.project.info.reports.plugin.version>3.2.1</maven.project.info.reports.plugin.version>
 
         <aggregate.report.dir>tests/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
         <sonar.exclusions>**/src/test/java/**/*.java</sonar.exclusions>

--- a/spi/src/main/java/pcap/spi/util/DefaultTimeout.java
+++ b/spi/src/main/java/pcap/spi/util/DefaultTimeout.java
@@ -17,6 +17,15 @@ public class DefaultTimeout implements Timeout {
   private final long microSecond;
 
   /**
+   * Create default timeout for 1 seconds.
+   *
+   * @since 1.4.2
+   */
+  public DefaultTimeout() {
+    this(1000000L, Precision.MICRO);
+  }
+
+  /**
    * Create timeout instance.
    *
    * @param timeout timeout.

--- a/spi/src/test/java/pcap/spi/util/DefaultTimeoutTest.java
+++ b/spi/src/test/java/pcap/spi/util/DefaultTimeoutTest.java
@@ -14,6 +14,13 @@ import pcap.spi.Timeout;
 class DefaultTimeoutTest {
 
   @Test
+  void defaultTimeout() {
+    DefaultTimeout timeout = new DefaultTimeout();
+    Assertions.assertEquals(1L, timeout.second());
+    Assertions.assertEquals(1000000L, timeout.microSecond());
+  }
+
+  @Test
   void nanoSecond() {
     DefaultTimeout timeout = new DefaultTimeout(1000000000L, Timeout.Precision.NANO);
     Assertions.assertEquals(1L, timeout.second());


### PR DESCRIPTION
Motivation:
Sometime we need default timeout. 

Modification:
Set default timeout for 1 sec.

Result:
No need to specify value for 1 sec timeout.