### PR TITLE
Remove packet length param

### DIFF
--- a/jdk7/src/main/java/pcap/jdk7/internal/BerkeleyPacketFilter.java
+++ b/jdk7/src/main/java/pcap/jdk7/internal/BerkeleyPacketFilter.java
@@ -73,14 +73,12 @@ class BerkeleyPacketFilter implements PacketFilter {
   @Override
   public boolean filter(PacketBuffer packetBuffer) {
     checkOpenState();
-    final long offset = packetBuffer.readerIndex();
-    final long capacity = packetBuffer.capacity();
-    final int packetLength = (int) (capacity - offset);
+    final int packetLength = (int) (packetBuffer.readableBytes());
     final DefaultPacketBuffer buffer = (DefaultPacketBuffer) packetBuffer;
     final long r = NativeMappings.bpf_filter(
             fp.bf_insns,
             buffer.buffer.share(buffer.readerIndex()),
-            (int) packetLength,
+            packetLength,
             (int) buffer.capacity());
     // not sure about this
     return r != 0 && r != 4294967295L;

--- a/jdk7/src/main/java/pcap/jdk7/internal/BerkeleyPacketFilter.java
+++ b/jdk7/src/main/java/pcap/jdk7/internal/BerkeleyPacketFilter.java
@@ -71,6 +71,22 @@ class BerkeleyPacketFilter implements PacketFilter {
   }
 
   @Override
+  public boolean filter(PacketBuffer packetBuffer) {
+    checkOpenState();
+    final long offset = packetBuffer.readerIndex();
+    final long capacity = packetBuffer.capacity();
+    final int packetLength = (int) (capacity - offset);
+    final DefaultPacketBuffer buffer = (DefaultPacketBuffer) packetBuffer;
+    final long r = NativeMappings.bpf_filter(
+            fp.bf_insns,
+            buffer.buffer.share(buffer.readerIndex()),
+            (int) packetLength,
+            (int) buffer.capacity());
+    // not sure about this
+    return r != 0 && r != 4294967295L;
+  }
+
+  @Override
   public void close() throws Exception {
     checkOpenState();
     NativeMappings.pcap_freecode(fp);

--- a/jdk7/src/test/java/pcap/jdk7/internal/BerkleyPacketFilterTest.java
+++ b/jdk7/src/test/java/pcap/jdk7/internal/BerkleyPacketFilterTest.java
@@ -59,9 +59,11 @@ class BerkleyPacketFilterTest extends BaseTest {
       buffer.writeBytes(bytes);
       try (PacketFilter filter = live.compile("udp port 443", true)) {
         Assertions.assertTrue(filter.filter(buffer, bytes.length));
+        Assertions.assertTrue(filter.filter(buffer));
       }
       try (PacketFilter filter = live.compile("udp port 53", true)) {
         Assertions.assertFalse(filter.filter(buffer, bytes.length));
+        Assertions.assertFalse(filter.filter(buffer));
       }
       Assertions.assertTrue(buffer.release());
     }

--- a/spi/src/main/java/pcap/spi/PacketFilter.java
+++ b/spi/src/main/java/pcap/spi/PacketFilter.java
@@ -12,11 +12,22 @@ public interface PacketFilter extends AutoCloseable {
 
   /**
    * Filter packet buffer.
+   * Deprecated: prevent user to pass unreasonable packet length.
    *
    * @param packetBuffer packet buffer.
    * @param packetLength packet original length.
    * @return returns {@code true} if filtered, {@code false} otherwise.
    */
+  @Deprecated
   @Incubating
   boolean filter(PacketBuffer packetBuffer, long packetLength);
+
+  /**
+   * Filter packet buffer.
+   *
+   * @param packetBuffer packet buffer.
+   * @return returns {@code true} if filtered, {@code false} otherwise.
+   */
+  @Incubating
+  boolean filter(PacketBuffer packetBuffer);
 }


### PR DESCRIPTION
Remove packet length param to prevent user to pass unreasonable arg