### PR TITLE
Adding dll search path for Npcap.

### DIFF
--- a/jdk7/src/main/java/pcap/jdk7/internal/NativeMappings.java
+++ b/jdk7/src/main/java/pcap/jdk7/internal/NativeMappings.java
@@ -61,13 +61,11 @@ class NativeMappings {
   private static final Map<String, Object> NATIVE_LOAD_LIBRARY_OPTIONS =
       new HashMap<String, Object>();
 
-  static final File NPCAP_DIR = Paths.get(System.getenv("SystemRoot"), "System32", "Npcap").toFile();
-
   static {
-    if (Platform.isWindows() && System.getProperty("jna.library.path") == null) {
-      if (NPCAP_DIR.exists()) {
-        NativeLibrary.addSearchPath("wpcap", NPCAP_DIR.getAbsolutePath());
-      }
+    File NPCAP_DIR = Paths.get(System.getenv("SystemRoot"), "System32", "Npcap").toFile();
+
+    if (Platform.isWindows() && System.getProperty("jna.library.path") == null && NPCAP_DIR.exists()) {
+      NativeLibrary.addSearchPath("wpcap", NPCAP_DIR.getAbsolutePath());
     }
   }
 

--- a/jdk7/src/main/java/pcap/jdk7/internal/NativeMappings.java
+++ b/jdk7/src/main/java/pcap/jdk7/internal/NativeMappings.java
@@ -62,10 +62,12 @@ class NativeMappings {
       new HashMap<String, Object>();
 
   static {
-    File NPCAP_DIR = Paths.get(System.getenv("SystemRoot"), "System32", "Npcap").toFile();
+    if (Platform.isWindows() && System.getProperty("jna.library.path") == null) {
+      File NPCAP_DIR = Paths.get(System.getenv("SystemRoot"), "System32", "Npcap").toFile();
 
-    if (Platform.isWindows() && System.getProperty("jna.library.path") == null && NPCAP_DIR.exists()) {
-      NativeLibrary.addSearchPath("wpcap", NPCAP_DIR.getAbsolutePath());
+      if (NPCAP_DIR.exists()) {
+        NativeLibrary.addSearchPath("wpcap", NPCAP_DIR.getAbsolutePath());
+      }
     }
   }
 

--- a/jdk7/src/main/java/pcap/jdk7/internal/NativeMappings.java
+++ b/jdk7/src/main/java/pcap/jdk7/internal/NativeMappings.java
@@ -16,9 +16,12 @@ import com.sun.jna.Pointer;
 import com.sun.jna.PointerType;
 import com.sun.jna.Structure;
 import com.sun.jna.ptr.PointerByReference;
+
+import java.io.File;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.nio.ByteOrder;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -57,6 +60,16 @@ class NativeMappings {
   private static final Logger LOG = LoggerFactory.getLogger(NativeMappings.class);
   private static final Map<String, Object> NATIVE_LOAD_LIBRARY_OPTIONS =
       new HashMap<String, Object>();
+
+  static final File NPCAP_DIR = Paths.get(System.getenv("SystemRoot"), "System32", "Npcap").toFile();
+
+  static {
+    if (Platform.isWindows() && System.getProperty("jna.library.path") == null) {
+      if (NPCAP_DIR.exists()) {
+        NativeLibrary.addSearchPath("wpcap", NPCAP_DIR.getAbsolutePath());
+      }
+    }
+  }
 
   static {
     com.sun.jna.Native.register(


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020-2023 Pcap Project
SPDX-License-Identifier: MIT OR Apache-2.0
-->

Motivation:

Allow this library to load Npcap without the Winpcap Compatibility Mode enabled.

Modification:

Added dll search path for C:\Windows\System32\Npcap

Result:

Fixes #294