### PR TITLE
Loopback size

### DIFF
--- a/codec/src/main/java/pcap/codec/loopback/Loopback.java
+++ b/codec/src/main/java/pcap/codec/loopback/Loopback.java
@@ -64,7 +64,7 @@ public final class Loopback extends AbstractPacket {
 
   /** {@inheritDoc} */
   @Override
-  protected int size() {
+  public int size() {
     return 4;
   }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020-2023 Pcap Project
SPDX-License-Identifier: MIT OR Apache-2.0
-->

Motivation:

Provide users access to `Loopback` `size` method.

Modification:

Change `Loopback` `size` method from `protected` to `public`.