### PR TITLE
Address use after free bug in `DefaultService.interfaces`.

### DIFF
--- a/jdk7/src/main/java/pcap/jdk7/internal/DefaultService.java
+++ b/jdk7/src/main/java/pcap/jdk7/internal/DefaultService.java
@@ -8,6 +8,8 @@ import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.PointerByReference;
 import java.net.Inet4Address;
+import java.util.Iterator;
+
 import pcap.common.logging.Logger;
 import pcap.common.logging.LoggerFactory;
 import pcap.spi.Address;
@@ -48,9 +50,57 @@ public class DefaultService implements Service {
     checkFindAllDevs(NativeMappings.pcap_findalldevs(alldevsPP, errbuf(true)));
 
     Pointer alldevsp = alldevsPP.getValue();
+
+    if (alldevsp == null) {
+      NativeMappings.pcap_freealldevs(alldevsPP.getPointer());
+      return new PcapInterface.NoInterface();
+    }
+
     NativeMappings.pcap_if pcapIf = new NativeMappings.pcap_if(alldevsp);
+
+    Iterator<Interface> iterator = pcapIf.iterator();
+
+    Interface first = null;
+    PcapInterface prev = null;
+
+    while (iterator.hasNext()) {
+      Interface next = iterator.next();
+
+      PcapInterface.PcapAddress firstAddress = null;
+      PcapInterface.PcapAddress prevAddress = null;
+
+      if (next.addresses() != null) {
+        Iterator<Address> addressIterator = next.addresses().iterator();
+
+        while (addressIterator.hasNext()) {
+            Address nextAddress = addressIterator.next();
+
+            PcapInterface.PcapAddress pcapAddress = new PcapInterface.PcapAddress(nextAddress.address(), nextAddress.netmask(), nextAddress.broadcast(), nextAddress.destination());
+
+            if (firstAddress == null) {
+                firstAddress = pcapAddress;
+            }
+            if (prevAddress != null) {
+                prevAddress.setNext(pcapAddress);
+            }
+            prevAddress = pcapAddress;
+        }
+      }
+
+      PcapInterface pcapInterface = new PcapInterface(next.name(), next.description(), firstAddress, next.flags());
+
+      if (first == null) {
+        first = pcapInterface;
+      }
+
+      if (prev != null) {
+        prev.setNext(pcapInterface);
+      }
+      prev = pcapInterface;
+    }
     NativeMappings.pcap_freealldevs(pcapIf.getPointer());
-    return pcapIf;
+
+    return first;
   }
 
   @Override

--- a/jdk7/src/main/java/pcap/jdk7/internal/PcapInterface.java
+++ b/jdk7/src/main/java/pcap/jdk7/internal/PcapInterface.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2020-2025 Pcap Project
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
 package pcap.jdk7.internal;
 
 import pcap.spi.Address;

--- a/jdk7/src/main/java/pcap/jdk7/internal/PcapInterface.java
+++ b/jdk7/src/main/java/pcap/jdk7/internal/PcapInterface.java
@@ -1,0 +1,132 @@
+package pcap.jdk7.internal;
+
+import pcap.spi.Address;
+import pcap.spi.Interface;
+
+import java.net.InetAddress;
+import java.util.Iterator;
+
+class PcapInterface implements Interface {
+    static class PcapAddress implements Address {
+        private Address next;
+        private final InetAddress address;
+        private final InetAddress netmask;
+        private final InetAddress broadcast;
+        private final InetAddress destination;
+
+        public PcapAddress() {
+            address = null;
+            netmask = null;
+            broadcast = null;
+            destination = null;
+        }
+
+        public PcapAddress(InetAddress address, InetAddress netmask, InetAddress broadcast, InetAddress destination) {
+            this.address = address;
+            this.netmask = netmask;
+            this.broadcast = broadcast;
+            this.destination = destination;
+        }
+
+        public void setNext(Address next) {
+            this.next = next;
+        }
+
+        @Override
+        public Address next() {
+            return next;
+        }
+
+        @Override
+        public InetAddress address() {
+            return address;
+        }
+
+        @Override
+        public InetAddress netmask() {
+            return netmask;
+        }
+
+        @Override
+        public InetAddress broadcast() {
+            return broadcast;
+        }
+
+        @Override
+        public InetAddress destination() {
+            return destination;
+        }
+
+        @Override
+        public Iterator<Address> iterator() {
+            return new DefaultAddressIterator(this);
+        }
+    }
+
+    public static class NoAddress extends PcapAddress {
+        @Override
+        public Iterator<Address> iterator() {
+            return new DefaultAddressIterator(null);
+        }
+    }
+
+    public static class NoInterface extends PcapInterface {
+        @Override
+        public Iterator<Interface> iterator() {
+            return new DefaultInterfaceIterator(null);
+        }
+    }
+    private Interface next;
+    private final String name;
+    private final String description;
+    private final Address address;
+    private final int flags;
+
+    public PcapInterface() {
+        name = "";
+        description = "";
+        address = new NoAddress();
+        flags = 0;
+    }
+
+    public PcapInterface(String name, String description, Address address, int flags) {
+        this.name = name;
+        this.description = description;
+        this.address = address;
+        this.flags = flags;
+    }
+
+    public void setNext(Interface next) {
+        this.next = next;
+    }
+
+    @Override
+    public Interface next() {
+        return next;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public String description() {
+        return description;
+    }
+
+    @Override
+    public Address addresses() {
+        return address;
+    }
+
+    @Override
+    public int flags() {
+        return flags;
+    }
+
+    @Override
+    public Iterator<Interface> iterator() {
+        return new DefaultInterfaceIterator(this);
+    }
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020-2023 Pcap Project
SPDX-License-Identifier: MIT OR Apache-2.0
-->

Motivation:

Address use after free bug that causes unexpected terminations.

Modification:

Read network interfaces out of native pointer and into Java objects of new type `PcapInterface`.

Result:

Fixes #315