### PR TITLE
Calling pcap_freealldevs with null seems to cause "java.lang.Error: Invalid memory access"

### DIFF
--- a/jdk7/src/main/java/pcap/jdk7/internal/DefaultService.java
+++ b/jdk7/src/main/java/pcap/jdk7/internal/DefaultService.java
@@ -52,7 +52,7 @@ public class DefaultService implements Service {
     Pointer alldevsp = alldevsPP.getValue();
 
     if (alldevsp == null) {
-      NativeMappings.pcap_freealldevs(alldevsPP.getPointer());
+      // no need to call pcap_freealldevs with null
       return new PcapInterface.NoInterface();
     }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020-2023 Pcap Project
SPDX-License-Identifier: MIT OR Apache-2.0
-->

Motivation:

Fix `java.lang.Error: Invalid memory access`

Modification:

Remove call to `pcap_freealldevs` when pointer returned by `pcap_findalldevs` is null.

Result:

No `java.lang.Error: Invalid memory access` is caused.